### PR TITLE
Prepare for release 4.0.5-beta.20200709

### DIFF
--- a/charts/stash-mongodb/Chart.yaml
+++ b/charts/stash-mongodb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'stash-mongodb - MongoDB database plugin for Stash by AppsCode'
 name: stash-mongodb
-version: 4.0.5-beta.20200708
-appVersion: 4.0.5-beta.20200708
+version: 4.0.5-beta.20200709
+appVersion: 4.0.5-beta.20200709
 home: https://github.com/stashed/mongodb
 icon: https://cdn.appscode.com/images/icon/stash.png
 sources:

--- a/charts/stash-mongodb/README.md
+++ b/charts/stash-mongodb/README.md
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install stash-mongodb-4.0.5-beta.20200708 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200708
+$ helm install stash-mongodb-4.0.5-beta.20200709 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200709
 ```
 
 ## Introduction
@@ -20,10 +20,10 @@ This chart deploys necessary `Function` and `Task` definition to backup or resto
 
 ## Installing the Chart
 
-To install the chart with the release name `stash-mongodb-4.0.5-beta.20200708`:
+To install the chart with the release name `stash-mongodb-4.0.5-beta.20200709`:
 
 ```console
-$ helm install stash-mongodb-4.0.5-beta.20200708 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200708
+$ helm install stash-mongodb-4.0.5-beta.20200709 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200709
 ```
 
 The command deploys necessary `Function` and `Task` definition to backup or restore MongoDB 4.0.5 using Stash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -32,10 +32,10 @@ The command deploys necessary `Function` and `Task` definition to backup or rest
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `stash-mongodb-4.0.5-beta.20200708`:
+To uninstall/delete the `stash-mongodb-4.0.5-beta.20200709`:
 
 ```console
-$ helm delete stash-mongodb-4.0.5-beta.20200708 -n kube-system
+$ helm delete stash-mongodb-4.0.5-beta.20200709 -n kube-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -60,12 +60,12 @@ The following table lists the configurable parameters of the `stash-mongodb` cha
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install stash-mongodb-4.0.5-beta.20200708 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200708 --set image.registry=stashed
+$ helm install stash-mongodb-4.0.5-beta.20200709 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200709 --set image.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install stash-mongodb-4.0.5-beta.20200708 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200708 --values values.yaml
+$ helm install stash-mongodb-4.0.5-beta.20200709 appscode/stash-mongodb -n kube-system --version=4.0.5-beta.20200709 --values values.yaml
 ```

--- a/charts/stash-mongodb/doc.yaml
+++ b/charts/stash-mongodb/doc.yaml
@@ -10,11 +10,11 @@ repository:
   name: appscode
 chart:
   name: stash-mongodb
-  version: 4.0.5-beta.20200708
+  version: 4.0.5-beta.20200709
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:
 - Kubernetes 1.11+
 release:
-  name: stash-mongodb-4.0.5-beta.20200708
+  name: stash-mongodb-4.0.5-beta.20200709
   namespace: kube-system

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	kmodules.xyz/offshoot-api v0.0.0-20200521035628-e135bf07b226
 	kubedb.dev/apimachinery v0.14.0-alpha.5
 	sigs.k8s.io/yaml v1.2.0
-	stash.appscode.dev/apimachinery v0.10.0-beta.0
+	stash.appscode.dev/apimachinery v0.10.0-beta.1
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1307,6 +1307,6 @@ software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237/go.mod h1:
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 stash.appscode.dev/apimachinery v0.10.0-alpha.0 h1:/CBUctjDJyjo9a9lANjAPRq3Fj1KygXddgoJKdGQ0Q8=
 stash.appscode.dev/apimachinery v0.10.0-alpha.0/go.mod h1:su9Q+3/B6+5PdGvVZBIkXoAik6iKKFUcdPNThpZPVV4=
-stash.appscode.dev/apimachinery v0.10.0-beta.0 h1:gIn9ai1ipjgGImTXJseOsucv3rJmQC4/34kihUWul4g=
-stash.appscode.dev/apimachinery v0.10.0-beta.0/go.mod h1:v3rBovazmdCv/9rAA5U7LpDRFhVqcLsagnLlbPfD2Eg=
+stash.appscode.dev/apimachinery v0.10.0-beta.1 h1:R1IhAhZ/iUbs2M+v9LYJacDCOmc4lk00JzSjVBrxOG0=
+stash.appscode.dev/apimachinery v0.10.0-beta.1/go.mod h1:v3rBovazmdCv/9rAA5U7LpDRFhVqcLsagnLlbPfD2Eg=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -813,7 +813,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.10.0-beta.0
+# stash.appscode.dev/apimachinery v0.10.0-beta.1
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.07.09-beta.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/2
Signed-off-by: 1gtm <1gtm@appscode.com>