### PR TITLE
Prepare for release 3.6.13-v4

### DIFF
--- a/charts/stash-mongodb/Chart.yaml
+++ b/charts/stash-mongodb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'stash-mongodb - MongoDB database plugin for Stash by AppsCode'
 name: stash-mongodb
-version: 3.6.13-v3
-appVersion: 3.6.13-v3
+version: 3.6.13-v4
+appVersion: 3.6.13-v4
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/mongodb-stash-addon.png
 sources:

--- a/charts/stash-mongodb/README.md
+++ b/charts/stash-mongodb/README.md
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install stash-mongodb-3.6.13-v3 appscode/stash-mongodb -n kube-system --version=3.6.13-v3
+$ helm install stash-mongodb-3.6.13-v4 appscode/stash-mongodb -n kube-system --version=3.6.13-v4
 ```
 
 ## Introduction
@@ -20,10 +20,10 @@ This chart deploys necessary `Function` and `Task` definition to backup or resto
 
 ## Installing the Chart
 
-To install the chart with the release name `stash-mongodb-3.6.13-v3`:
+To install the chart with the release name `stash-mongodb-3.6.13-v4`:
 
 ```console
-$ helm install stash-mongodb-3.6.13-v3 appscode/stash-mongodb -n kube-system --version=3.6.13-v3
+$ helm install stash-mongodb-3.6.13-v4 appscode/stash-mongodb -n kube-system --version=3.6.13-v4
 ```
 
 The command deploys necessary `Function` and `Task` definition to backup or restore MongoDB 3.6.13 using Stash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -32,10 +32,10 @@ The command deploys necessary `Function` and `Task` definition to backup or rest
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `stash-mongodb-3.6.13-v3`:
+To uninstall/delete the `stash-mongodb-3.6.13-v4`:
 
 ```console
-$ helm delete stash-mongodb-3.6.13-v3 -n kube-system
+$ helm delete stash-mongodb-3.6.13-v4 -n kube-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the `stash-mongodb` cha
 | fullnameOverride | Overrides fullname template                                                                                                   | `""`            |
 | image.registry   | Docker registry used to pull MongoDB addon image                                                                              | `stashed`       |
 | image.repository | Docker image used to backup/restore MongoDB database                                                                          | `stash-mongodb` |
-| image.tag        | Tag of the image that is used to backup/restore MongoDB database. This is usually same as the database version it can backup. | `3.6.13-v3`     |
+| image.tag        | Tag of the image that is used to backup/restore MongoDB database. This is usually same as the database version it can backup. | `3.6.13-v4`     |
 | backup.args      | Arguments to pass to `mongodump` command during backup process                                                                | `""`            |
 | restore.args     | Arguments to pass to `mongorestore` command during restore process                                                            | `""`            |
 | maxConcurrency   | Maximum concurrency to perform backup or restore tasks                                                                        | `3`             |
@@ -60,12 +60,12 @@ The following table lists the configurable parameters of the `stash-mongodb` cha
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install stash-mongodb-3.6.13-v3 appscode/stash-mongodb -n kube-system --version=3.6.13-v3 --set image.registry=stashed
+$ helm install stash-mongodb-3.6.13-v4 appscode/stash-mongodb -n kube-system --version=3.6.13-v4 --set image.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install stash-mongodb-3.6.13-v3 appscode/stash-mongodb -n kube-system --version=3.6.13-v3 --values values.yaml
+$ helm install stash-mongodb-3.6.13-v4 appscode/stash-mongodb -n kube-system --version=3.6.13-v4 --values values.yaml
 ```

--- a/charts/stash-mongodb/doc.yaml
+++ b/charts/stash-mongodb/doc.yaml
@@ -10,11 +10,11 @@ repository:
   name: appscode
 chart:
   name: stash-mongodb
-  version: 3.6.13-v3
+  version: 3.6.13-v4
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:
 - Kubernetes 1.11+
 release:
-  name: stash-mongodb-3.6.13-v3
+  name: stash-mongodb-3.6.13-v4
   namespace: kube-system

--- a/charts/stash-mongodb/values.yaml
+++ b/charts/stash-mongodb/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: stash-mongodb
   # Tag of the image that is used to backup/restore MongoDB database.
   # This is usually same as the database version it can backup.
-  tag: 3.6.13-v3
+  tag: 3.6.13-v4
 # optional argument to send mongodump or mongorestore command
 backup:
   # Arguments to pass to `mongodump` command during backup process

--- a/docs/examples/backup/replicaset/backupconfiguration-replicaset.yaml
+++ b/docs/examples/backup/replicaset/backupconfiguration-replicaset.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: mongodb-backup-3.6.13-v3
+    name: mongodb-backup-3.6.13-v4
   repository:
     name: gcs-repo-replicaset
   target:

--- a/docs/examples/backup/replicaset/standalone-backup.yaml
+++ b/docs/examples/backup/replicaset/standalone-backup.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: mongodb-backup-3.6.13-v3
+    name: mongodb-backup-3.6.13-v4
   repository:
     name: gcs-repo-custom
   target:

--- a/docs/examples/backup/sharding/backupconfiguration-sharding.yaml
+++ b/docs/examples/backup/sharding/backupconfiguration-sharding.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: mongodb-backup-3.6.13-v3
+    name: mongodb-backup-3.6.13-v4
   repository:
     name: gcs-repo-sharding
   target:

--- a/docs/examples/backup/sharding/standalone-backup.yaml
+++ b/docs/examples/backup/sharding/standalone-backup.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: mongodb-backup-3.6.13-v3
+    name: mongodb-backup-3.6.13-v4
   repository:
     name: gcs-repo-custom
   target:

--- a/docs/examples/backup/standalone/backupconfiguration.yaml
+++ b/docs/examples/backup/standalone/backupconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: mongodb-backup-3.6.13-v3
+    name: mongodb-backup-3.6.13-v4
   repository:
     name: gcs-repo
   target:

--- a/docs/examples/restore/replicaset/restoresession-replicaset.yaml
+++ b/docs/examples/restore/replicaset/restoresession-replicaset.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: MongoDB
 spec:
   task:
-    name: mongodb-restore-3.6.13-v3
+    name: mongodb-restore-3.6.13-v4
   repository:
     name: gcs-repo-replicaset
   target:

--- a/docs/examples/restore/replicaset/restoresession-standalone.yaml
+++ b/docs/examples/restore/replicaset/restoresession-standalone.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: MongoDB
 spec:
   task:
-    name: mongodb-restore-3.6.13-v3
+    name: mongodb-restore-3.6.13-v4
   repository:
     name: gcs-repo-custom
   target:

--- a/docs/examples/restore/sharding/restoresession-sharding.yaml
+++ b/docs/examples/restore/sharding/restoresession-sharding.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: MongoDB
 spec:
   task:
-    name: mongodb-restore-3.6.13-v3
+    name: mongodb-restore-3.6.13-v4
   repository:
     name: gcs-repo-sharding
   target:

--- a/docs/examples/restore/sharding/restoresession-standalone.yaml
+++ b/docs/examples/restore/sharding/restoresession-standalone.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: MongoDB
 spec:
   task:
-    name: mongodb-restore-3.6.13-v3
+    name: mongodb-restore-3.6.13-v4
   repository:
     name: gcs-repo-custom
   target:

--- a/docs/examples/restore/standalone/restoresession.yaml
+++ b/docs/examples/restore/standalone/restoresession.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: MongoDB
 spec:
   task:
-    name: mongodb-restore-3.6.13-v3
+    name: mongodb-restore-3.6.13-v4
   repository:
     name: gcs-repo
   target:

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	kubedb.dev/apimachinery v0.14.0-beta.2
 	sigs.k8s.io/yaml v1.2.0
-	stash.appscode.dev/apimachinery v0.11.6-0.20201106214826-132a511faa97
+	stash.appscode.dev/apimachinery v0.11.6
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1328,6 +1328,6 @@ software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237/go.mod h1:
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 stash.appscode.dev/apimachinery v0.10.0 h1:zKmaANWOTH89J7a/D1FwXFUWAQdI1rA5Nr82WbnLGm8=
 stash.appscode.dev/apimachinery v0.10.0/go.mod h1:TpdBIAiHCtpkUB13SDUyCZ6y+5wmzXBMAf9e72cSPO4=
-stash.appscode.dev/apimachinery v0.11.6-0.20201106214826-132a511faa97 h1:UR+jW3PbIPmdG1fWLVSIYiOsBsnMSc55feLZCvobXjQ=
-stash.appscode.dev/apimachinery v0.11.6-0.20201106214826-132a511faa97/go.mod h1:JQtqMYDOMkcxmcsUnOiRhi/BIvFWlceAIcauBw1a48M=
+stash.appscode.dev/apimachinery v0.11.6 h1:6JPVYugF6YdeSuLtFqeXTyi6k04owD6E6PxDTBpRsn4=
+stash.appscode.dev/apimachinery v0.11.6/go.mod h1:JQtqMYDOMkcxmcsUnOiRhi/BIvFWlceAIcauBw1a48M=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -888,7 +888,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.11.6-0.20201106214826-132a511faa97
+# stash.appscode.dev/apimachinery v0.11.6
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.11.06
Release-tracker: https://github.com/stashed/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>