### PR TITLE
Prepare for release 4.1.13-v17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	kmodules.xyz/custom-resources v0.24.0
 	kmodules.xyz/offshoot-api v0.24.1
 	kubedb.dev/apimachinery v0.27.1-0.20220616092651-6571aa028218
-	stash.appscode.dev/apimachinery v0.20.2-0.20220616125513-e19298fd23b1
+	stash.appscode.dev/apimachinery v0.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1103,5 +1103,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.20.2-0.20220616125513-e19298fd23b1 h1:wUr0lPX6zzdWq1dyeIbYkQvrzhW8/YERyII6iyi9IE4=
-stash.appscode.dev/apimachinery v0.20.2-0.20220616125513-e19298fd23b1/go.mod h1:mtxrytXCX8271F5xVMKTwVPoERs6XbhLZlhRKJU08uI=
+stash.appscode.dev/apimachinery v0.21.0 h1:uK4IAuT3+V7b2/sQAWslQ3iT8agN6qgy58gg9W51rhk=
+stash.appscode.dev/apimachinery v0.21.0/go.mod h1:mtxrytXCX8271F5xVMKTwVPoERs6XbhLZlhRKJU08uI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -650,7 +650,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.20.2-0.20220616125513-e19298fd23b1
+# stash.appscode.dev/apimachinery v0.21.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.06.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/49
Signed-off-by: 1gtm <1gtm@appscode.com>