### PR TITLE
Prepare for release 4.0.3-v21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	kmodules.xyz/custom-resources v0.25.0
 	kmodules.xyz/offshoot-api v0.25.0
 	kubedb.dev/apimachinery v0.28.4-0.20220918021210-a0b96812228b
-	stash.appscode.dev/apimachinery v0.24.0
+	stash.appscode.dev/apimachinery v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -908,5 +908,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.24.0 h1:bMEySRvft1WYZX8EpYQR5Lqsi280/WKOYVUpqXRTTuM=
-stash.appscode.dev/apimachinery v0.24.0/go.mod h1:AdK7wfKZXqlL5g30ceuMw/7nEVW3AOemQVWjc03sI3k=
+stash.appscode.dev/apimachinery v0.25.0 h1:+j8kc164AXd9p8CdeWsvlMLugVFlRGlbARqKz+pLgcQ=
+stash.appscode.dev/apimachinery v0.25.0/go.mod h1:AdK7wfKZXqlL5g30ceuMw/7nEVW3AOemQVWjc03sI3k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -668,7 +668,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.24.0
+# stash.appscode.dev/apimachinery v0.25.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories

--- a/vendor/stash.appscode.dev/apimachinery/apis/constants.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/constants.go
@@ -157,8 +157,8 @@ const (
 	StashCronJobContainer = "stash-trigger"
 	LocalVolumeName       = "stash-local"
 	ScratchDirVolumeName  = "stash-scratchdir"
-	TmpDirVolumeName      = "tmp-dir"
-	TmpDirMountPath       = "/tmp"
+	TmpDirVolumeName      = "stash-tmp-dir"
+	TmpDirMountPath       = "/stash-tmp"
 	PodinfoVolumeName     = "stash-podinfo"
 
 	RecoveryJobPrefix   = "stash-recovery-"

--- a/vendor/stash.appscode.dev/apimachinery/pkg/restic/config.go
+++ b/vendor/stash.appscode.dev/apimachinery/pkg/restic/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	DefaultOutputFileName = "output.json"
-	DefaultScratchDir     = "/tmp"
+	DefaultScratchDir     = "/stash-tmp"
 	DefaultHost           = "host-0"
 )
 


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.01.05
Release-tracker: https://github.com/stashed/CHANGELOG/pull/60
Signed-off-by: 1gtm <1gtm@appscode.com>